### PR TITLE
Add support for Python 3.6, drop Python 3.3.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = src
+
+[report]
+exclude_lines =
+    pragma: no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,26 @@
 language: python
 sudo: false
 python:
-    - 2.7
-    - 3.3
-    - 3.4
-    - 3.5
-    - pypy
-    - pypy3
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy-5.6.0
+  - pypy3.3-5.5-alpha
 install:
-    - pip install .
-    - pip install zope.error[test]
+  - pip install -U pip setuptools
+  - pip install -U coveralls coverage
+  - pip install -U -e ".[test]"
 script:
-    - python setup.py test -q
+  - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
+
+after_success:
+  - coveralls
+
 notifications:
     email: false
+
+cache: pip
+
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,12 @@
 Changes
 =======
 
-4.3.1 (unreleased)
+4.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop support for Python 3.3.
+
+- Add support for Python 3.6.
 
 
 4.3.0 (2016-07-07)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,9 +2,10 @@ include *.txt
 include bootstrap.py
 include buildout.cfg
 include MANIFEST.in
+
 recursive-include src *.zcml
 
-# added by check_manifest.py
 include *.rst
 include .travis.yml
 include tox.ini
+include .coveragerc

--- a/README.rst
+++ b/README.rst
@@ -4,4 +4,8 @@
 .. image:: https://travis-ci.org/zopefoundation/zope.error.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.error
 
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.error/badge.svg
+        :target: https://coveralls.io/github/zopefoundation/zope.error
+
+
 This package provides an error reporting utility which is able to store errors.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -28,51 +28,55 @@ def read(*rnames):
         return f.read()
 
 setup(name='zope.error',
-    version='4.3.1.dev0',
-    author='Zope Foundation and Contributors',
-    author_email='zope-dev@zope.org',
-    description = "An error reporting utility for Zope3",
-    long_description=(
-        read('README.rst')
-        + '\n\n' +
-        read('CHANGES.rst')
-        ),
-    license='ZPL 2.1',
-    keywords = "zope3 error",
-    classifiers = [
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Zope Public License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Topic :: Internet :: WWW/HTTP',
-        'Framework :: Zope3'],
-    url='http://pypi.python.org/pypi/zope.error',
-	packages=find_packages('src'),
-	package_dir = {'': 'src'},
-    namespace_packages=['zope',],
-    install_requires=['setuptools',
-                      'zope.exceptions',
-                      'zope.interface',
-                      'zope.location',
-                      'persistent', # error.py imports from persistent
-                      'six'
-                      ],
-    extras_require=dict(
-          test=[
+      version='4.4.0.dev0',
+      author='Zope Foundation and Contributors',
+      author_email='zope-dev@zope.org',
+      description="An error reporting utility for Zope3",
+      long_description=(
+          read('README.rst')
+          + '\n\n' +
+          read('CHANGES.rst')
+      ),
+      license='ZPL 2.1',
+      keywords="zope3 error",
+      classifiers=[
+          'Development Status :: 5 - Production/Stable',
+          'Environment :: Web Environment',
+          'Intended Audience :: Developers',
+          'License :: OSI Approved :: Zope Public License',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: Implementation :: CPython',
+          'Programming Language :: Python :: Implementation :: PyPy',
+          'Natural Language :: English',
+          'Operating System :: OS Independent',
+          'Topic :: Internet :: WWW/HTTP',
+          'Framework :: Zope3',
+      ],
+      url='http://github.com/zopefoundation/zope.error',
+      packages=find_packages('src'),
+      package_dir={'': 'src'},
+      namespace_packages=['zope',],
+      install_requires=[
+          'setuptools',
+          'zope.exceptions',
+          'zope.interface',
+          'zope.location',
+          'persistent', # error.py imports from persistent
+          'six',
+      ],
+      extras_require={
+          'test': [
               'zope.testing >= 3.8',
-              ]),
-    test_suite = 'zope.error.tests',
-    include_package_data = True,
-    zip_safe = False,
-    )
+              'zope.testrunner',
+          ],
+      },
+      test_suite='zope.error.tests',
+      include_package_data=True,
+      zip_safe=False,
+)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/error/error.py
+++ b/src/zope/error/error.py
@@ -296,5 +296,5 @@ try:
     from zope.testing.cleanup import addCleanUp
     addCleanUp(_clear)
     del addCleanUp
-except ImportError:
+except ImportError: # pragma: no cover
     pass

--- a/src/zope/error/tests.py
+++ b/src/zope/error/tests.py
@@ -17,16 +17,13 @@ import sys
 import unittest
 import logging
 
+from io import StringIO
+
 from zope.exceptions.exceptionformatter import format_exception
 from zope.testing import cleanup
 
 from zope.error.error import ErrorReportingUtility, getFormattedException
-from zope.error._compat import _u_type, PYTHON2, _basestring
-
-if PYTHON2:
-    from cStringIO import StringIO
-else:
-    from io import StringIO
+from zope.error._compat import _u_type, _basestring
 
 class Error(Exception):
 
@@ -230,19 +227,19 @@ class GetPrintableTests(unittest.TestCase):
             raise Exception('<boom>')
         except:
             self.assertTrue("Exception: &lt;boom&gt;" in
-                          getFormattedException(sys.exc_info()))
-        else:
+                            getFormattedException(sys.exc_info()))
+        else: # pragma: no cover
             self.fail("Exception was not raised (should never happen)")
 
     def test_getFormattedException_as_html(self):
         try:
             raise Exception('<boom>')
         except:
-            fe =  getFormattedException(sys.exc_info(), as_html=True);
-            self.assertTrue("<p>Traceback (most recent call last):</p>" in fe)
-            self.assertTrue("</ul><p>Exception: &lt;boom&gt;<br />" in fe)
-            self.assertTrue("</p><br />" in fe)
-        else:
+            fe = getFormattedException(sys.exc_info(), as_html=True);
+            self.assertIn("<p>Traceback (most recent call last):</p>", fe)
+            self.assertIn("</ul><p>Exception: &lt;boom&gt;<br />", fe)
+            self.assertIn("</p><br />", fe)
+        else: # pragma: no cover
             self.fail("Exception was not raised (should never happen)")
 
         # If this fails because you get '&lt;br /&gt;' instead of '<br />' at

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,pypy3
+envlist = py27,py34,py35,py36,pypy,pypy3
 
 [testenv]
 commands =
-    python setup.py -q test -q
-deps = 
-    zope.testing
-    six
+    zope-testrunner --test-path=src
+deps =
+    .[test]

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,6 @@ envlist = py27,py34,py35,py36,pypy,pypy3
 
 [testenv]
 commands =
-    zope-testrunner --test-path=src
+    zope-testrunner --test-path=src []
 deps =
     .[test]


### PR DESCRIPTION
Switch to zope.testrunner instead of setup.py test. Enable coverage and coveralls.

Whitespace gardening in setup.py.