### PR TITLE
A tox environment for coverage.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,3 +6,15 @@ commands =
     zope-testrunner --test-path=src []
 deps =
     .[test]
+
+[testenv:coverage]
+commands =
+    coverage run -m zope.testrunner --test-path=src []
+    coverage report -m
+# The combo of skip_install and install_command lets
+# us test the source, meaning coverage reports come out
+# correct
+skip_install = true
+install_command = pip install -e {[testenv]deps} {packages}
+deps =
+    coverage

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27,py34,py35,py36,pypy,pypy3
 
 [testenv]
+usedevelop = true
 commands =
     zope-testrunner --test-path=src []
 deps =
@@ -11,10 +12,6 @@ deps =
 commands =
     coverage run -m zope.testrunner --test-path=src []
     coverage report -m
-# The combo of skip_install and install_command lets
-# us test the source, meaning coverage reports come out
-# correct
-skip_install = true
-install_command = pip install -e {[testenv]deps} {packages}
 deps =
+    {[testenv]deps}
     coverage


### PR DESCRIPTION
```
$ tox -e coverage
GLOB sdist-make: //zope.error/setup.py
coverage installed: coverage==4.4.1,persistent==4.2.4.2,six==1.10.0,-e git+https://github.com/zopefoundation/zope.error.git@92700bb5f119dc7b9e4b5652282cdc2186b33e66#egg=zope.error,zope.event==4.2.0,zope.exceptions==4.1.0,zope.interface==4.4.2,zope.location==4.0.3,zope.proxy==4.2.1,zope.schema==4.5.0,zope.testing==4.6.2,zope.testrunner==4.7.0
coverage runtests: PYTHONHASHSEED='1507888529'
coverage runtests: commands[0] | coverage run -m zope.testrunner --test-path=src
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Ran 31 tests with 0 failures, 0 errors and 0 skipped in 0.009 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
coverage runtests: commands[1] | coverage report -m
Name                           Stmts   Miss  Cover   Missing
------------------------------------------------------------
src/zope/__init__.py               0      0   100%
src/zope/error/__init__.py         0      0   100%
src/zope/error/_compat.py          6      0   100%
src/zope/error/error.py          155      0   100%
src/zope/error/interfaces.py      10      0   100%
src/zope/error/tests.py          225      0   100%
------------------------------------------------------------
TOTAL                            396      0   100%
```